### PR TITLE
List Changes

### DIFF
--- a/data/leveldata.json
+++ b/data/leveldata.json
@@ -1,5 +1,5 @@
 {
-  "GeradoEm": "12/3/2024 14:0:23",
+  "GeradoEm": "12/3/2024 15:59:55",
   "TipoData": "level",
   "Data": [
     {
@@ -749,6 +749,15 @@
     },
     {
       "position_lvl": 90,
+      "id_lvl": "84871408",
+      "name_lvl": "Cristal Hollows",
+      "creator_lvl": "IcyWindy",
+      "verifier_lvl": "IcyWindy",
+      "video_lvl": "https://www.youtube.com/watch?v=QnMEbfXgw_U",
+      "publisher_lvl": "zPowers"
+    },
+    {
+      "position_lvl": 91,
       "id_lvl": "9004118",
       "name_lvl": "Armageddon",
       "creator_lvl": "Hakkou",
@@ -756,7 +765,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=slPyW4_jYI4"
     },
     {
-      "position_lvl": 91,
+      "position_lvl": 92,
       "id_lvl": "56893115",
       "name_lvl": "Theory of Cody",
       "creator_lvl": "Cloud76",
@@ -764,7 +773,7 @@
       "video_lvl": "https://youtu.be/sh9ADqhE-sQ"
     },
     {
-      "position_lvl": 92,
+      "position_lvl": 93,
       "id_lvl": "7203561",
       "name_lvl": "Classical",
       "creator_lvl": "Hakkou",
@@ -772,47 +781,7 @@
       "video_lvl": "https://youtu.be/x_5LrqzrTWY"
     },
     {
-      "position_lvl": 93,
-      "id_lvl": "16488260",
-      "name_lvl": "ShockWave",
-      "creator_lvl": "LChaseR",
-      "verifier_lvl": "RalucaGranola",
-      "video_lvl": "https://www.youtube.com/watch?v=haQw98gv10s"
-    },
-    {
       "position_lvl": 94,
-      "id_lvl": "72612321",
-      "name_lvl": "Tormenta",
-      "creator_lvl": "SawiArtz",
-      "verifier_lvl": "Luyzdume",
-      "video_lvl": "https://youtu.be/509Th77agCk"
-    },
-    {
-      "position_lvl": 95,
-      "id_lvl": "43732369",
-      "name_lvl": "Colorful Circles",
-      "creator_lvl": "Itocp",
-      "verifier_lvl": "Akane",
-      "video_lvl": "https://youtu.be/4rFeqrrvT58"
-    },
-    {
-      "position_lvl": 96,
-      "id_lvl": "14594318",
-      "name_lvl": "Power Surge",
-      "creator_lvl": "Fusi0n",
-      "verifier_lvl": "RalucaGranola",
-      "video_lvl": "https://youtu.be/oOWr4q-_9rQ"
-    },
-    {
-      "position_lvl": 97,
-      "id_lvl": "24805105",
-      "name_lvl": "Fairy Tree",
-      "creator_lvl": "HidekiX",
-      "verifier_lvl": "HidekiX",
-      "video_lvl": "https://www.youtube.com/watch?v=_fIbZAMrsyI"
-    },
-    {
-      "position_lvl": 98,
       "id_lvl": "44282966",
       "name_lvl": "The Abstract Rocket",
       "creator_lvl": "fakeblast",
@@ -820,7 +789,47 @@
       "video_lvl": "https://youtu.be/LS4tNEjE-Ik"
     },
     {
+      "position_lvl": 95,
+      "id_lvl": "16488260",
+      "name_lvl": "ShockWave",
+      "creator_lvl": "LChaseR",
+      "verifier_lvl": "RalucaGranola",
+      "video_lvl": "https://www.youtube.com/watch?v=haQw98gv10s"
+    },
+    {
+      "position_lvl": 96,
+      "id_lvl": "72612321",
+      "name_lvl": "Tormenta",
+      "creator_lvl": "SawiArtz",
+      "verifier_lvl": "Luyzdume",
+      "video_lvl": "https://youtu.be/509Th77agCk"
+    },
+    {
+      "position_lvl": 97,
+      "id_lvl": "43732369",
+      "name_lvl": "Colorful Circles",
+      "creator_lvl": "Itocp",
+      "verifier_lvl": "Akane",
+      "video_lvl": "https://youtu.be/4rFeqrrvT58"
+    },
+    {
+      "position_lvl": 98,
+      "id_lvl": "14594318",
+      "name_lvl": "Power Surge",
+      "creator_lvl": "Fusi0n",
+      "verifier_lvl": "RalucaGranola",
+      "video_lvl": "https://youtu.be/oOWr4q-_9rQ"
+    },
+    {
       "position_lvl": 99,
+      "id_lvl": "24805105",
+      "name_lvl": "Fairy Tree",
+      "creator_lvl": "HidekiX",
+      "verifier_lvl": "HidekiX",
+      "video_lvl": "https://www.youtube.com/watch?v=_fIbZAMrsyI"
+    },
+    {
+      "position_lvl": 100,
       "id_lvl": "100937178",
       "name_lvl": "Shining Star",
       "creator_lvl": "IReMaster22I",
@@ -828,7 +837,7 @@
       "video_lvl": "https://youtu.be/WRm37kJ1Ayk?si=fL96OPt8e7IqOnkQ"
     },
     {
-      "position_lvl": 100,
+      "position_lvl": 101,
       "id_lvl": "9682304",
       "name_lvl": "Golden Hope",
       "creator_lvl": "Terron",
@@ -836,7 +845,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=S_-lUpsYO4c"
     },
     {
-      "position_lvl": 101,
+      "position_lvl": 102,
       "id_lvl": "39495014",
       "name_lvl": "Despacito Circles",
       "creator_lvl": "Terron",
@@ -844,7 +853,7 @@
       "video_lvl": "https://youtu.be/dllr4vIym_U"
     },
     {
-      "position_lvl": 102,
+      "position_lvl": 103,
       "id_lvl": "56172558",
       "name_lvl": "Python",
       "creator_lvl": "joojmiguel",
@@ -852,7 +861,7 @@
       "video_lvl": "https://youtu.be/w8JoQ4firrM"
     },
     {
-      "position_lvl": 103,
+      "position_lvl": 104,
       "id_lvl": "51865473",
       "name_lvl": "Diamond Rose",
       "creator_lvl": "MrMeurick",
@@ -860,7 +869,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=hpW8rK3gopM"
     },
     {
-      "position_lvl": 104,
+      "position_lvl": 105,
       "id_lvl": "26313242",
       "name_lvl": "Star Apart",
       "creator_lvl": "HidekiX",
@@ -868,7 +877,7 @@
       "video_lvl": "https://youtu.be/vWhtdepF_RI"
     },
     {
-      "position_lvl": 105,
+      "position_lvl": 106,
       "id_lvl": "78721973",
       "name_lvl": "Didi",
       "creator_lvl": "Ivanpercie",
@@ -876,7 +885,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=48KjptSisn0"
     },
     {
-      "position_lvl": 106,
+      "position_lvl": 107,
       "id_lvl": "81097263",
       "name_lvl": "Summer Breeze",
       "creator_lvl": "TeamFodase",
@@ -884,7 +893,7 @@
       "video_lvl": "https://youtu.be/EslZazE5rYY"
     },
     {
-      "position_lvl": 107,
+      "position_lvl": 108,
       "id_lvl": "94563744",
       "name_lvl": "tipo B",
       "creator_lvl": "classic10",
@@ -892,7 +901,7 @@
       "video_lvl": "https://youtu.be/KIb8mqjvxqM"
     },
     {
-      "position_lvl": 108,
+      "position_lvl": 109,
       "id_lvl": "91261175",
       "name_lvl": "Nuclear Flash",
       "creator_lvl": "TeamFodase",
@@ -900,7 +909,7 @@
       "video_lvl": "https://youtu.be/Rwzeri_MSUs"
     },
     {
-      "position_lvl": 109,
+      "position_lvl": 110,
       "id_lvl": "97553430",
       "name_lvl": "CreationShip",
       "creator_lvl": "Laranjoo",


### PR DESCRIPTION
Gerado automaticamente por DLBRauto em 12/03/2024, 15:59:57 (SP).
Alterações feitas por: RalucaGranola

Cristal Hollows foi adicionado em #90, acima de Armageddon e abaixo de Gusta Cyclone, colocando Golden Hope na legacy list

The Abstract Rocket foi subiu de #99 para #94, (antes acima de Shining Star e abaixo de Fairy Tree) agora estando acima de ShockWave e abaixo de Classical