### PR TITLE
List Changes

### DIFF
--- a/data/leveldata.json
+++ b/data/leveldata.json
@@ -1,5 +1,5 @@
 {
-  "GeradoEm": "16/3/2024 0:30:9",
+  "GeradoEm": "16/3/2024 20:30:52",
   "TipoData": "level",
   "Data": [
     {
@@ -113,6 +113,15 @@
     },
     {
       "position_lvl": 13,
+      "id_lvl": "102547674",
+      "name_lvl": "O Pau Finale",
+      "creator_lvl": "RalucaGranola",
+      "verifier_lvl": "RalucaGranola",
+      "video_lvl": "https://youtu.be/9fcAittQZzM",
+      "listpct_lvl": 44
+    },
+    {
+      "position_lvl": 14,
       "id_lvl": "86333527",
       "name_lvl": "The Prata",
       "creator_lvl": "rafabirds",
@@ -121,7 +130,7 @@
       "listpct_lvl": 39
     },
     {
-      "position_lvl": 14,
+      "position_lvl": 15,
       "id_lvl": "37792861",
       "name_lvl": "Factory Realm X",
       "creator_lvl": "HelpegasuS",
@@ -130,7 +139,7 @@
       "listpct_lvl": 54
     },
     {
-      "position_lvl": 15,
+      "position_lvl": 16,
       "id_lvl": "96281195",
       "name_lvl": "sacrify",
       "creator_lvl": "maxfs",
@@ -139,7 +148,7 @@
       "listpct_lvl": 54
     },
     {
-      "position_lvl": 16,
+      "position_lvl": 17,
       "id_lvl": "57095359",
       "name_lvl": "Astronaut Vortex",
       "creator_lvl": "Yuuchouze",
@@ -148,7 +157,7 @@
       "listpct_lvl": 55
     },
     {
-      "position_lvl": 17,
+      "position_lvl": 18,
       "id_lvl": "99604264",
       "name_lvl": "ABOROTERETA",
       "creator_lvl": "RalucaGranola",
@@ -157,7 +166,7 @@
       "listpct_lvl": 54
     },
     {
-      "position_lvl": 18,
+      "position_lvl": 19,
       "id_lvl": "48091316",
       "name_lvl": "Elusions",
       "creator_lvl": "Cloud76",
@@ -166,7 +175,7 @@
       "listpct_lvl": 57
     },
     {
-      "position_lvl": 19,
+      "position_lvl": 20,
       "id_lvl": "58417850",
       "name_lvl": "Dolos",
       "creator_lvl": "Enzeux",
@@ -175,7 +184,7 @@
       "listpct_lvl": 51
     },
     {
-      "position_lvl": 20,
+      "position_lvl": 21,
       "id_lvl": "79660012",
       "name_lvl": "Purple Light ",
       "creator_lvl": "fellipe123446f",
@@ -184,7 +193,7 @@
       "listpct_lvl": 45
     },
     {
-      "position_lvl": 21,
+      "position_lvl": 22,
       "id_lvl": "96290402",
       "name_lvl": "Ultra Deadlocked",
       "creator_lvl": "vit12",
@@ -193,7 +202,7 @@
       "listpct_lvl": 55
     },
     {
-      "position_lvl": 22,
+      "position_lvl": 23,
       "id_lvl": "63524957",
       "name_lvl": "The Green",
       "creator_lvl": "yuuchouze",
@@ -203,7 +212,7 @@
       "listpct_lvl": 60
     },
     {
-      "position_lvl": 23,
+      "position_lvl": 24,
       "id_lvl": "95327529",
       "name_lvl": "Collapse",
       "creator_lvl": "fwefwe",
@@ -212,7 +221,7 @@
       "listpct_lvl": 61
     },
     {
-      "position_lvl": 24,
+      "position_lvl": 25,
       "id_lvl": "85288009",
       "name_lvl": "Dorabae choose way5",
       "creator_lvl": "fwefwe",
@@ -221,29 +230,20 @@
       "listpct_lvl": 75
     },
     {
-      "position_lvl": 25,
+      "position_lvl": 26,
       "id_lvl": "80814750",
       "name_lvl": "Convy",
       "creator_lvl": "rafabirds",
       "verifier_lvl": "L3on14az",
-      "video_lvl": "https://youtu.be/mXzYW4rI0Pc",
-      "listpct_lvl": 60
+      "video_lvl": "https://youtu.be/mXzYW4rI0Pc"
     },
     {
-      "position_lvl": 26,
+      "position_lvl": 27,
       "id_lvl": "64073938",
       "name_lvl": "The Zodiac",
       "creator_lvl": "RalucaGranola",
       "verifier_lvl": "RalucaGranola",
       "video_lvl": "https://youtu.be/gRsd4yiL_8c"
-    },
-    {
-      "position_lvl": 27,
-      "id_lvl": "87524727",
-      "name_lvl": "birds difficult 3",
-      "creator_lvl": "rafabirds",
-      "verifier_lvl": "RalucaGranola",
-      "video_lvl": "https://youtu.be/Wc0pWiGqI9E"
     },
     {
       "position_lvl": 28,
@@ -295,6 +295,14 @@
     },
     {
       "position_lvl": 34,
+      "id_lvl": "87524727",
+      "name_lvl": "birds difficult 3",
+      "creator_lvl": "rafabirds",
+      "verifier_lvl": "RalucaGranola",
+      "video_lvl": "https://youtu.be/Wc0pWiGqI9E"
+    },
+    {
+      "position_lvl": 35,
       "id_lvl": "50076317",
       "name_lvl": "Blood Attack",
       "creator_lvl": "LChaseR",
@@ -302,7 +310,7 @@
       "video_lvl": "https://youtu.be/D-dBM5O52Ks"
     },
     {
-      "position_lvl": 35,
+      "position_lvl": 36,
       "id_lvl": "62290029",
       "name_lvl": "Extermination Nation",
       "creator_lvl": "Yuuchouze",
@@ -310,7 +318,15 @@
       "video_lvl": "https://youtu.be/Q2Syva4rS-s"
     },
     {
-      "position_lvl": 36,
+      "position_lvl": 37,
+      "id_lvl": "97091006",
+      "name_lvl": "Doideira",
+      "creator_lvl": "RalucaGranola",
+      "verifier_lvl": "RalucaGranola",
+      "video_lvl": "https://youtu.be/h1X5jKJ14_E"
+    },
+    {
+      "position_lvl": 38,
       "id_lvl": "63534667",
       "name_lvl": "The Next Horizon",
       "creator_lvl": "Onnerus1",
@@ -318,7 +334,7 @@
       "video_lvl": "https://youtu.be/LFbceikN0Ws"
     },
     {
-      "position_lvl": 37,
+      "position_lvl": 39,
       "id_lvl": "92424054",
       "name_lvl": "narcissist",
       "creator_lvl": "Guill",
@@ -326,7 +342,7 @@
       "video_lvl": "https://youtu.be/IHOJ8DvKchA"
     },
     {
-      "position_lvl": 38,
+      "position_lvl": 40,
       "id_lvl": "95918210",
       "name_lvl": "Fragile",
       "creator_lvl": "maxfs",
@@ -335,7 +351,7 @@
       "publisher_lvl": "pointercrate19"
     },
     {
-      "position_lvl": 39,
+      "position_lvl": 41,
       "id_lvl": "88854750",
       "name_lvl": "UNDERGROUND",
       "creator_lvl": "HugoLA",
@@ -343,7 +359,7 @@
       "video_lvl": "https://youtu.be/e0L2gkVmWy8"
     },
     {
-      "position_lvl": 40,
+      "position_lvl": 42,
       "id_lvl": "80966929",
       "name_lvl": "Eraser",
       "creator_lvl": "LChaseR",
@@ -351,7 +367,7 @@
       "video_lvl": "https://youtu.be/kJmqWS9iVyA"
     },
     {
-      "position_lvl": 41,
+      "position_lvl": 43,
       "id_lvl": "85386027",
       "name_lvl": "Extreme Ship Level",
       "creator_lvl": "Petalite",
@@ -359,7 +375,7 @@
       "video_lvl": "https://youtu.be/7s2cp76g0SQ"
     },
     {
-      "position_lvl": 42,
+      "position_lvl": 44,
       "id_lvl": "101284159",
       "name_lvl": "Faithful Constance",
       "creator_lvl": "TeamArgo",
@@ -367,7 +383,7 @@
       "video_lvl": "https://youtu.be/cGd7v6ZswPU"
     },
     {
-      "position_lvl": 43,
+      "position_lvl": 45,
       "id_lvl": "61830500",
       "name_lvl": "Death Machine",
       "creator_lvl": "Yuuchouze",
@@ -375,7 +391,7 @@
       "video_lvl": "https://youtu.be/gT--CLIBvsQ"
     },
     {
-      "position_lvl": 44,
+      "position_lvl": 46,
       "id_lvl": "96454896",
       "name_lvl": "ASAP",
       "creator_lvl": "Yuuchouze",
@@ -383,15 +399,7 @@
       "video_lvl": "https://youtu.be/NSAIjPU-cAA"
     },
     {
-      "position_lvl": 45,
-      "id_lvl": "97091006",
-      "name_lvl": "Doideira",
-      "creator_lvl": "RalucaGranola",
-      "verifier_lvl": "RalucaGranola",
-      "video_lvl": "https://youtu.be/h1X5jKJ14_E"
-    },
-    {
-      "position_lvl": 46,
+      "position_lvl": 47,
       "id_lvl": "66477646",
       "name_lvl": "Black Tourmaline",
       "creator_lvl": "OverDCE",
@@ -399,7 +407,7 @@
       "video_lvl": "https://youtu.be/lKTeVum3xjw"
     },
     {
-      "position_lvl": 47,
+      "position_lvl": 48,
       "id_lvl": "55489425",
       "name_lvl": "Intention",
       "creator_lvl": "yuuchouze",
@@ -408,7 +416,7 @@
       "publisher_lvl": "akaanee"
     },
     {
-      "position_lvl": 48,
+      "position_lvl": 49,
       "id_lvl": "89819173",
       "name_lvl": "Underwater Caves",
       "creator_lvl": "rafabirds",
@@ -416,7 +424,7 @@
       "video_lvl": "https://youtu.be/DwvCjaSpknI"
     },
     {
-      "position_lvl": 49,
+      "position_lvl": 50,
       "id_lvl": "90451473",
       "name_lvl": "CHALLUNGA FINALE",
       "creator_lvl": "rafabirds",
@@ -424,7 +432,7 @@
       "video_lvl": "https://youtu.be/fFiIamH3Qxs"
     },
     {
-      "position_lvl": 50,
+      "position_lvl": 51,
       "id_lvl": "100928011",
       "name_lvl": "Darkness Blood X",
       "creator_lvl": "robsonedu",
@@ -433,7 +441,7 @@
       "publisher_lvl": "RalucaGranola"
     },
     {
-      "position_lvl": 51,
+      "position_lvl": 52,
       "id_lvl": "92837602",
       "name_lvl": "Tio Desconhecido XVI",
       "creator_lvl": "HankAlemao",
@@ -442,7 +450,7 @@
       "publisher_lvl": "RalucaGranola"
     },
     {
-      "position_lvl": 52,
+      "position_lvl": 53,
       "id_lvl": "33080047",
       "name_lvl": "Speed Of Silence X",
       "creator_lvl": "HelpegasuS",
@@ -451,7 +459,7 @@
       "publisher_lvl": "MrTopson"
     },
     {
-      "position_lvl": 53,
+      "position_lvl": 54,
       "id_lvl": "81115403",
       "name_lvl": "Rolas Tortas e Lisas",
       "creator_lvl": "RalucaGranola",
@@ -459,7 +467,7 @@
       "video_lvl": "https://youtu.be/U-6xpuA6o18"
     },
     {
-      "position_lvl": 54,
+      "position_lvl": 55,
       "id_lvl": "82023514",
       "name_lvl": "Silent Sunk",
       "creator_lvl": "Petalite",
@@ -467,7 +475,7 @@
       "video_lvl": "https://youtu.be/cZGmmAe8mtk"
     },
     {
-      "position_lvl": 55,
+      "position_lvl": 56,
       "id_lvl": "81218331",
       "name_lvl": "SUPER FURIA",
       "creator_lvl": "AVRG",
@@ -475,7 +483,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=JVTp2USVz4Y"
     },
     {
-      "position_lvl": 56,
+      "position_lvl": 57,
       "id_lvl": "67662419",
       "name_lvl": "setesh",
       "creator_lvl": "Nar247",
@@ -483,7 +491,7 @@
       "video_lvl": "https://youtu.be/fHR8kSo7VH4"
     },
     {
-      "position_lvl": 57,
+      "position_lvl": 58,
       "id_lvl": "91293455",
       "name_lvl": "Glacial Edge",
       "creator_lvl": "HelpegasuS",
@@ -492,7 +500,7 @@
       "publisher_lvl": "Legoyoshi3"
     },
     {
-      "position_lvl": 58,
+      "position_lvl": 59,
       "id_lvl": "2487191",
       "name_lvl": "Creeper Force",
       "creator_lvl": "CreeperMILK",
@@ -500,7 +508,7 @@
       "video_lvl": "https://youtu.be/l2Kk2re3rJo"
     },
     {
-      "position_lvl": 59,
+      "position_lvl": 60,
       "id_lvl": "101632373",
       "name_lvl": "Ascent II",
       "creator_lvl": "rafabirds",
@@ -509,7 +517,7 @@
       "publisher_lvl": "fellipe123446f"
     },
     {
-      "position_lvl": 60,
+      "position_lvl": 61,
       "id_lvl": "84228977",
       "name_lvl": "THE MIND ELECTRIC",
       "creator_lvl": "Petalite",
@@ -517,7 +525,7 @@
       "video_lvl": "https://youtu.be/lrOmUCjXSQY"
     },
     {
-      "position_lvl": 61,
+      "position_lvl": 62,
       "id_lvl": "64625805",
       "name_lvl": "Crimson Disorder",
       "creator_lvl": "Nar247",
@@ -525,7 +533,7 @@
       "video_lvl": "https://youtu.be/Ep42s1J6xak"
     },
     {
-      "position_lvl": 62,
+      "position_lvl": 63,
       "id_lvl": "54789455",
       "name_lvl": "Hellgate",
       "creator_lvl": "Firy",
@@ -533,7 +541,7 @@
       "video_lvl": "https://youtu.be/L52J7vVfQyk"
     },
     {
-      "position_lvl": 63,
+      "position_lvl": 64,
       "id_lvl": "77853681",
       "name_lvl": "SOOO CRAZY",
       "creator_lvl": "rafabirds",
@@ -541,7 +549,7 @@
       "video_lvl": "https://youtu.be/K_fLj1QqxMY"
     },
     {
-      "position_lvl": 64,
+      "position_lvl": 65,
       "id_lvl": "33383668",
       "name_lvl": "NecroDynamix",
       "creator_lvl": "HelpegasuS",
@@ -549,7 +557,7 @@
       "video_lvl": "https://youtu.be/1SpA7qCicSQ"
     },
     {
-      "position_lvl": 65,
+      "position_lvl": 66,
       "id_lvl": "77975737",
       "name_lvl": "SubStratum",
       "creator_lvl": "Cloud76",
@@ -557,7 +565,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=yxWiymTSR0k"
     },
     {
-      "position_lvl": 66,
+      "position_lvl": 67,
       "id_lvl": "44507360",
       "name_lvl": "Ascension",
       "creator_lvl": "LChaseR",
@@ -565,7 +573,7 @@
       "video_lvl": "https://youtu.be/Q6bB5WRsmY0"
     },
     {
-      "position_lvl": 67,
+      "position_lvl": 68,
       "id_lvl": "60732092",
       "name_lvl": "The Ultimate Party",
       "creator_lvl": "Ale708",
@@ -573,7 +581,7 @@
       "video_lvl": "https://youtu.be/N-bqcqJ-V2E"
     },
     {
-      "position_lvl": 68,
+      "position_lvl": 69,
       "id_lvl": "92639961",
       "name_lvl": "AbacaxiDosSRozeira",
       "creator_lvl": "RalucaGranola",
@@ -581,7 +589,7 @@
       "video_lvl": "https://youtu.be/xTLWi4sHXKE"
     },
     {
-      "position_lvl": 69,
+      "position_lvl": 70,
       "id_lvl": "62489808",
       "name_lvl": "MEMORY ZONE",
       "creator_lvl": "Yuuchouze",
@@ -589,7 +597,7 @@
       "video_lvl": "https://youtu.be/NEKHjleH3ig"
     },
     {
-      "position_lvl": 70,
+      "position_lvl": 71,
       "id_lvl": "85823029",
       "name_lvl": "Good and Evil",
       "creator_lvl": "Petalite",
@@ -597,7 +605,7 @@
       "video_lvl": "https://youtu.be/AMq3Kf6-oto"
     },
     {
-      "position_lvl": 71,
+      "position_lvl": 72,
       "id_lvl": "79892744",
       "name_lvl": "The Ashlands",
       "creator_lvl": "rafabirds",
@@ -605,7 +613,7 @@
       "video_lvl": "https://youtu.be/4PadPnkAE64"
     },
     {
-      "position_lvl": 72,
+      "position_lvl": 73,
       "id_lvl": "97559226",
       "name_lvl": "H e x x e r",
       "creator_lvl": "SamukaGD",
@@ -613,7 +621,7 @@
       "video_lvl": "https://youtu.be/61YyR55_Wj0"
     },
     {
-      "position_lvl": 73,
+      "position_lvl": 74,
       "id_lvl": "46420829",
       "name_lvl": "Mythical Space II",
       "creator_lvl": "iImagnumIi",
@@ -621,7 +629,7 @@
       "video_lvl": "https://youtu.be/hA7ny5Sy-0o?si=WIMAGVuxWI6ku502"
     },
     {
-      "position_lvl": 74,
+      "position_lvl": 75,
       "id_lvl": "43118149",
       "name_lvl": "Rebirth II",
       "creator_lvl": "HelpegasuS",
@@ -629,7 +637,7 @@
       "video_lvl": "https://youtu.be/VU-2i9PD7xc"
     },
     {
-      "position_lvl": 75,
+      "position_lvl": 76,
       "id_lvl": "80535690",
       "name_lvl": "Boomerang",
       "creator_lvl": "teris700",
@@ -637,7 +645,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=xZ5IKicGbAw"
     },
     {
-      "position_lvl": 76,
+      "position_lvl": 77,
       "id_lvl": "48814064",
       "name_lvl": "TecnoCore",
       "creator_lvl": "ItsKeichi",
@@ -645,7 +653,7 @@
       "video_lvl": "https://youtu.be/3Q5xKcDrYEk?si=G8qKP6M2kQFTsaAQ"
     },
     {
-      "position_lvl": 77,
+      "position_lvl": 78,
       "id_lvl": "93788082",
       "name_lvl": "EHrebus",
       "creator_lvl": "Knali2001",
@@ -654,7 +662,7 @@
       "publisher_lvl": "RalucaGranola"
     },
     {
-      "position_lvl": 78,
+      "position_lvl": 79,
       "id_lvl": "25531397",
       "name_lvl": "Dark Skies",
       "creator_lvl": "HelpegasuS",
@@ -662,7 +670,7 @@
       "video_lvl": "https://youtu.be/OlltYB1WH4M"
     },
     {
-      "position_lvl": 79,
+      "position_lvl": 80,
       "id_lvl": "26219827",
       "name_lvl": "Factory Realm",
       "creator_lvl": "LuizGamer2234",
@@ -670,7 +678,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=f8Dbp79SW0c"
     },
     {
-      "position_lvl": 80,
+      "position_lvl": 81,
       "id_lvl": "63561968",
       "name_lvl": "Grandmaster",
       "creator_lvl": "Yuuchouze",
@@ -678,7 +686,7 @@
       "video_lvl": "https://youtu.be/MHuObYHsh10"
     },
     {
-      "position_lvl": 81,
+      "position_lvl": 82,
       "id_lvl": "64612787",
       "name_lvl": "Zacarias",
       "creator_lvl": "vit12",
@@ -686,7 +694,7 @@
       "video_lvl": "https://youtu.be/0-QS385ttLc"
     },
     {
-      "position_lvl": 82,
+      "position_lvl": 83,
       "id_lvl": "21538451",
       "name_lvl": "Darkness07",
       "creator_lvl": "Hakkou",
@@ -694,7 +702,7 @@
       "video_lvl": "https://youtu.be/QdYx_tcccdE"
     },
     {
-      "position_lvl": 83,
+      "position_lvl": 84,
       "id_lvl": "77455408",
       "name_lvl": "mussum",
       "creator_lvl": "Nidroo",
@@ -702,7 +710,7 @@
       "video_lvl": "https://youtu.be/kI8jBlRLMKo"
     },
     {
-      "position_lvl": 84,
+      "position_lvl": 85,
       "id_lvl": "53895600",
       "name_lvl": "Hell Light",
       "creator_lvl": "LuyzDumeOld",
@@ -710,7 +718,7 @@
       "video_lvl": "https://youtu.be/rRZY5XSZtYw"
     },
     {
-      "position_lvl": 85,
+      "position_lvl": 86,
       "id_lvl": "63245954",
       "name_lvl": "Cursed Nightmare",
       "creator_lvl": "Ghotstav",
@@ -718,7 +726,7 @@
       "video_lvl": "https://youtu.be/Clt-sEpJ0v0"
     },
     {
-      "position_lvl": 86,
+      "position_lvl": 87,
       "id_lvl": "72154204",
       "name_lvl": "Death Ascension",
       "creator_lvl": "rafabirds",
@@ -726,7 +734,7 @@
       "video_lvl": "https://youtu.be/RoV9kCYU_rw"
     },
     {
-      "position_lvl": 87,
+      "position_lvl": 88,
       "id_lvl": "89298291",
       "name_lvl": "HuShErr",
       "creator_lvl": "Johh01",
@@ -734,7 +742,7 @@
       "video_lvl": "https://youtu.be/-hOKSbdGfWo"
     },
     {
-      "position_lvl": 88,
+      "position_lvl": 89,
       "id_lvl": "86462021",
       "name_lvl": "eu tenho probleminha",
       "creator_lvl": "RalucaGranola",
@@ -742,7 +750,7 @@
       "video_lvl": "https://youtu.be/LmrYrq6S4r0"
     },
     {
-      "position_lvl": 89,
+      "position_lvl": 90,
       "id_lvl": "90163362",
       "name_lvl": "Brasil Level",
       "creator_lvl": "RalucaGranola",
@@ -750,7 +758,7 @@
       "video_lvl": "https://youtu.be/Vl0pdgD_QLI"
     },
     {
-      "position_lvl": 90,
+      "position_lvl": 91,
       "id_lvl": "73129026",
       "name_lvl": "yume 2kki",
       "creator_lvl": "RalucaGranola",
@@ -758,7 +766,7 @@
       "video_lvl": "https://youtu.be/cn347Hmdxhw"
     },
     {
-      "position_lvl": 91,
+      "position_lvl": 92,
       "id_lvl": "81103953",
       "name_lvl": "Sakupen Poopin",
       "creator_lvl": "Petalite",
@@ -766,7 +774,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=Zw_o4EUeHcE"
     },
     {
-      "position_lvl": 92,
+      "position_lvl": 93,
       "id_lvl": "79848867",
       "name_lvl": "vinistep",
       "creator_lvl": "vinihard2",
@@ -775,7 +783,7 @@
       "publisher_lvl": "rafabirds"
     },
     {
-      "position_lvl": 93,
+      "position_lvl": 94,
       "id_lvl": "38134796",
       "name_lvl": "One More Light",
       "creator_lvl": "Mitz",
@@ -783,7 +791,7 @@
       "video_lvl": "https://youtu.be/4o3ZzEqsYyE?si=8XnnAhpzxwJcu2--"
     },
     {
-      "position_lvl": 94,
+      "position_lvl": 95,
       "id_lvl": "16299302",
       "name_lvl": "Telluric Universe",
       "creator_lvl": "Fusi0n",
@@ -791,7 +799,15 @@
       "video_lvl": "https://youtu.be/L6M-q9ayZ-Q"
     },
     {
-      "position_lvl": 95,
+      "position_lvl": 96,
+      "id_lvl": "44282966",
+      "name_lvl": "The Abstract Rocket",
+      "creator_lvl": "fakeblast",
+      "verifier_lvl": "fakeblast",
+      "video_lvl": "https://youtu.be/LS4tNEjE-Ik"
+    },
+    {
+      "position_lvl": 97,
       "id_lvl": "88851982",
       "name_lvl": "Gusta Cyclone",
       "creator_lvl": "TheR3alGusta",
@@ -799,7 +815,7 @@
       "video_lvl": "https://youtu.be/MQ6XT4VcMr4"
     },
     {
-      "position_lvl": 96,
+      "position_lvl": 98,
       "id_lvl": "84871408",
       "name_lvl": "Cristal Hollows",
       "creator_lvl": "IcyWindy",
@@ -808,7 +824,7 @@
       "publisher_lvl": "zPowers"
     },
     {
-      "position_lvl": 97,
+      "position_lvl": 99,
       "id_lvl": "9004118",
       "name_lvl": "Armageddon",
       "creator_lvl": "Hakkou",
@@ -816,7 +832,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=slPyW4_jYI4"
     },
     {
-      "position_lvl": 98,
+      "position_lvl": 100,
       "id_lvl": "56893115",
       "name_lvl": "Theory of Cody",
       "creator_lvl": "Cloud76",
@@ -824,7 +840,7 @@
       "video_lvl": "https://youtu.be/sh9ADqhE-sQ"
     },
     {
-      "position_lvl": 99,
+      "position_lvl": 101,
       "id_lvl": "7203561",
       "name_lvl": "Classical",
       "creator_lvl": "Hakkou",
@@ -832,15 +848,7 @@
       "video_lvl": "https://youtu.be/x_5LrqzrTWY"
     },
     {
-      "position_lvl": 100,
-      "id_lvl": "44282966",
-      "name_lvl": "The Abstract Rocket",
-      "creator_lvl": "fakeblast",
-      "verifier_lvl": "fakeblast",
-      "video_lvl": "https://youtu.be/LS4tNEjE-Ik"
-    },
-    {
-      "position_lvl": 101,
+      "position_lvl": 102,
       "id_lvl": "80328810",
       "name_lvl": "robson josue",
       "creator_lvl": "rafabirds",
@@ -848,7 +856,7 @@
       "video_lvl": "https://youtu.be/CPpjOWrzwUI"
     },
     {
-      "position_lvl": 102,
+      "position_lvl": 103,
       "id_lvl": "16488260",
       "name_lvl": "ShockWave",
       "creator_lvl": "LChaseR",
@@ -856,7 +864,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=haQw98gv10s"
     },
     {
-      "position_lvl": 103,
+      "position_lvl": 104,
       "id_lvl": "72612321",
       "name_lvl": "Tormenta",
       "creator_lvl": "SawiArtz",
@@ -864,7 +872,7 @@
       "video_lvl": "https://youtu.be/509Th77agCk"
     },
     {
-      "position_lvl": 104,
+      "position_lvl": 105,
       "id_lvl": "43732369",
       "name_lvl": "Colorful Circles",
       "creator_lvl": "Itocp",
@@ -872,7 +880,7 @@
       "video_lvl": "https://youtu.be/4rFeqrrvT58"
     },
     {
-      "position_lvl": 105,
+      "position_lvl": 106,
       "id_lvl": "14594318",
       "name_lvl": "Power Surge",
       "creator_lvl": "Fusi0n",
@@ -880,7 +888,7 @@
       "video_lvl": "https://youtu.be/oOWr4q-_9rQ"
     },
     {
-      "position_lvl": 106,
+      "position_lvl": 107,
       "id_lvl": "24805105",
       "name_lvl": "Fairy Tree",
       "creator_lvl": "HidekiX",
@@ -888,7 +896,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=_fIbZAMrsyI"
     },
     {
-      "position_lvl": 107,
+      "position_lvl": 108,
       "id_lvl": "100937178",
       "name_lvl": "Shining Star",
       "creator_lvl": "IReMaster22I",
@@ -896,7 +904,7 @@
       "video_lvl": "https://youtu.be/WRm37kJ1Ayk?si=fL96OPt8e7IqOnkQ"
     },
     {
-      "position_lvl": 108,
+      "position_lvl": 109,
       "id_lvl": "9682304",
       "name_lvl": "Golden Hope",
       "creator_lvl": "Terron",
@@ -904,7 +912,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=S_-lUpsYO4c"
     },
     {
-      "position_lvl": 109,
+      "position_lvl": 110,
       "id_lvl": "39495014",
       "name_lvl": "Despacito Circles",
       "creator_lvl": "Terron",
@@ -912,7 +920,7 @@
       "video_lvl": "https://youtu.be/dllr4vIym_U"
     },
     {
-      "position_lvl": 110,
+      "position_lvl": 111,
       "id_lvl": "56172558",
       "name_lvl": "Python",
       "creator_lvl": "joojmiguel",
@@ -920,7 +928,7 @@
       "video_lvl": "https://youtu.be/w8JoQ4firrM"
     },
     {
-      "position_lvl": 111,
+      "position_lvl": 112,
       "id_lvl": "51865473",
       "name_lvl": "Diamond Rose",
       "creator_lvl": "MrMeurick",
@@ -928,7 +936,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=hpW8rK3gopM"
     },
     {
-      "position_lvl": 112,
+      "position_lvl": 113,
       "id_lvl": "26313242",
       "name_lvl": "Star Apart",
       "creator_lvl": "HidekiX",
@@ -936,7 +944,7 @@
       "video_lvl": "https://youtu.be/vWhtdepF_RI"
     },
     {
-      "position_lvl": 113,
+      "position_lvl": 114,
       "id_lvl": "78721973",
       "name_lvl": "Didi",
       "creator_lvl": "Ivanpercie",
@@ -944,7 +952,7 @@
       "video_lvl": "https://www.youtube.com/watch?v=48KjptSisn0"
     },
     {
-      "position_lvl": 114,
+      "position_lvl": 115,
       "id_lvl": "81097263",
       "name_lvl": "Summer Breeze",
       "creator_lvl": "TeamFodase",
@@ -952,7 +960,7 @@
       "video_lvl": "https://youtu.be/EslZazE5rYY"
     },
     {
-      "position_lvl": 115,
+      "position_lvl": 116,
       "id_lvl": "94563744",
       "name_lvl": "tipo B",
       "creator_lvl": "classic10",
@@ -960,7 +968,7 @@
       "video_lvl": "https://youtu.be/KIb8mqjvxqM"
     },
     {
-      "position_lvl": 116,
+      "position_lvl": 117,
       "id_lvl": "91261175",
       "name_lvl": "Nuclear Flash",
       "creator_lvl": "TeamFodase",
@@ -968,7 +976,7 @@
       "video_lvl": "https://youtu.be/Rwzeri_MSUs"
     },
     {
-      "position_lvl": 117,
+      "position_lvl": 118,
       "id_lvl": "97553430",
       "name_lvl": "CreationShip",
       "creator_lvl": "Laranjoo",


### PR DESCRIPTION
Gerado automaticamente por DLBRauto em 16/03/2024, 20:30:54 (SP).
Alterações feitas por: RalucaGranola

O Pau Finale foi adicionado em #13, acima de The Prata e abaixo de Super Probably Dash, colocando Convy na extended list e Classical (considerando o move de The Abstract Rocket menciondo abaixo) na legacy list

The Abstract Rocket foi movido de #101 (legacy) para #96, agora acima de Gusta Cyclone e abaixo de Telluric Universe

Doideira foi movido de #46 para #36, agora acima de The Next Horizon e abaixo de Extermination Nation

Birds Difficult 3 foi movido de #28 para #34, agora acima de Blood Attack e abaixo de The Ultimate Demon